### PR TITLE
Fix CocoaPods badge link target [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AppDevKit
 [![Build Status](https://travis-ci.org/yahoo/AppDevKit.svg?branch=master)](https://travis-ci.org/yahoo/AppDevKit) 
 [![codecov](https://codecov.io/gh/yahoo/AppDevKit/branch/master/graph/badge.svg)](https://codecov.io/gh/yahoo/AppDevKit)
-[![CocoaPods](https://img.shields.io/cocoapods/v/AppDevKit.svg?maxAge=2592000?style=flat-square)](https://github.com/yahoo/AppDevKit)
+[![CocoaPods](https://img.shields.io/cocoapods/v/AppDevKit.svg?maxAge=2592000?style=flat-square)](https://cocoapods.org/?q=appdevkit)
 
 AppDevKit is an iOS development library that provides foundational and developer everyday required features for their iOS app development. It has been used by Yahoo’s iOS app production for 3 years, and future outsourcing apps will also be using AppDevKit. The stability and scalability has been verified on these production apps. It makes difficult development tasks easier and has saved 30% development time in real case. It also covers incompatibility issues caused by different iOS platforms.
 


### PR DESCRIPTION
Minor fix as title. Clicking the CocoaPods badge should take viewer to the CocoaPods page.
