### PR TITLE
Fix Pull-To-Refresh on iOS11.

### DIFF
--- a/AppDevPods/AppDevUIKit/UIScrollView+ADKPullToRefreshView.m
+++ b/AppDevPods/AppDevUIKit/UIScrollView+ADKPullToRefreshView.m
@@ -246,7 +246,16 @@ NSString * const pullToRefreshContentViewBottomMarginKey;
             }
         }
         CGFloat scrollOffsetLimit = self.scrollView.pullToRefreshViewHeight * triggerDistanceTimes;
+#ifdef __IPHONE_11_0
+        CGFloat scrollOffsetThreshold;
+        if (@available(iOS 11, *)) {
+            scrollOffsetThreshold = contentOffset.y + self.scrollView.adjustedContentInset.top + scrollOffsetLimit;
+        } else {
+            scrollOffsetThreshold = contentOffset.y + self.scrollView.contentInset.top + scrollOffsetLimit;
+        }
+#else
         CGFloat scrollOffsetThreshold = contentOffset.y + self.scrollView.contentInset.top + scrollOffsetLimit;
+#endif
 
         if (self.scrollView.isDragging && self.state == ADKPullToRefreshStateStopped && scrollOffsetThreshold < scrollOffsetLimit) {
             self.state = ADKPullToRefreshStateDragging;


### PR DESCRIPTION
Pull-to-refresh triggers reloading immediately even pulling down for a
very short distance then releasing on iOS 11.  This PR fixes it.

The root cause is that safe area insets are introduced in iOS 11.  We
should respect it as the contentInsets doesn't seem to adjust anymore.

If we're going to use the old way to adjust contentInsets,
contentInsetAdjustmentBehavior should set to
UIScrollViewContentInsetAdjustmentNever, then adjust contentInsets in
the old way.  Pull-To-Refresh will just work as expected.