### PR TITLE
Handling prepareForReuse case in ADKCellDynamicSizeCalculator

### DIFF
--- a/AppDevKit/Info.plist
+++ b/AppDevKit/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.3</string>
+	<string>1.2.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1509763113</string>
+	<string>1510560607</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/AppDevKit/SampleVCollectionViewCell.h
+++ b/AppDevKit/SampleVCollectionViewCell.h
@@ -16,5 +16,6 @@
 @property (weak, nonatomic) IBOutlet UIImageView *imageView;
 @property (weak, nonatomic) IBOutlet UILabel *titleLabel;
 @property (weak, nonatomic) IBOutlet UILabel *descriptionLabel;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *cellTopConstraint;
 
 @end

--- a/AppDevKit/SampleVCollectionViewCell.m
+++ b/AppDevKit/SampleVCollectionViewCell.m
@@ -36,6 +36,12 @@
     self.imageView.layer.cornerRadius = CGRectGetWidth(self.imageView.bounds) * 0.5f;
 }
 
+- (void)prepareForReuse
+{
+    // If you need to modify some calculation for adjusting layouts, you can put you code here. ADKCellDynamicSizeCalulator will invoice prepareForReuse method automatically.
+    // self.cellTopConstraint.constant = 50.0f;
+}
+
 - (void)layoutSubviews
 {
     [super layoutSubviews];

--- a/AppDevKit/SampleVCollectionViewCell.xib
+++ b/AppDevKit/SampleVCollectionViewCell.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -12,6 +16,7 @@
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="100"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Taiwan-Flag.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="7vB-FB-UOP">
                         <rect key="frame" x="15" y="10" width="80" height="80"/>
@@ -26,7 +31,7 @@
                             <constraint firstAttribute="height" constant="22" id="u7w-qB-AMo"/>
                         </constraints>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="Description" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="381-JR-aMq">
@@ -35,13 +40,12 @@
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="42" id="gLB-fH-Gh0"/>
                         </constraints>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                        <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
-                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             </view>
-            <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="7vB-FB-UOP" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="15" id="3ed-KH-iVK"/>
                 <constraint firstItem="7vB-FB-UOP" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="10" id="HWt-2F-SsP"/>
@@ -55,6 +59,7 @@
             </constraints>
             <size key="customSize" width="320" height="98"/>
             <connections>
+                <outlet property="cellTopConstraint" destination="fov-FN-lJO" id="Hzi-r2-63m"/>
                 <outlet property="descriptionLabel" destination="381-JR-aMq" id="Ga1-Sz-dMH"/>
                 <outlet property="imageView" destination="7vB-FB-UOP" id="cXH-nz-Zb8"/>
                 <outlet property="titleLabel" destination="4ah-I7-i7P" id="iXC-dt-RbV"/>

--- a/AppDevPods/AppDevListViewKit/ADKCellDynamicSizeCalculator.m
+++ b/AppDevPods/AppDevListViewKit/ADKCellDynamicSizeCalculator.m
@@ -31,6 +31,9 @@
     if ([cellInstance isKindOfClass:[UICollectionViewCell class]] || [cellInstance isKindOfClass:[UITableViewCell class]]) {
         UIView *cell = cellInstance;
         cell.bounds = CGRectMake(0.0f, 0.0f, preferredSize.width, 0.0f);
+        if ([cell respondsToSelector:@selector(prepareForReuse)]) {
+            [cell performSelector:@selector(prepareForReuse)];
+        }
         [cell layoutIfNeeded];
         UIView *contentView = [cell performSelector:@selector(contentView)];
         CGSize resultSize = [contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
@@ -48,6 +51,9 @@
     if ([cellInstance isKindOfClass:[UICollectionViewCell class]] || [cellInstance isKindOfClass:[UITableViewCell class]]) {
         UIView *cell = cellInstance;
         cell.bounds = CGRectMake(0.0f, 0.0f, 0.0f, preferredSize.height);
+        if ([cell respondsToSelector:@selector(prepareForReuse)]) {
+            [cell performSelector:@selector(prepareForReuse)];
+        }
         [cell layoutIfNeeded];
         UIView *contentView = [cell performSelector:@selector(contentView)];
         CGSize resultSize = [contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];


### PR DESCRIPTION
Modifying ADKCellDynamicSizeCalculator to support the situation that developers want to modify layouts when cells will be reused.