### PR TITLE
Fix warnings

### DIFF
--- a/AppDevPods/AppDevCommonKit/ADKAppUtil.h
+++ b/AppDevPods/AppDevCommonKit/ADKAppUtil.h
@@ -16,49 +16,49 @@
  *
  *  @return YES if screen is longer than iPhone 4 / 4s and iPad.
  */
-BOOL ADKIsLongerScreen();
+BOOL ADKIsLongerScreen(void);
 
 /**
  *  @brief Check device's screen is larger than smallest size, e.g 320.0f. iPhone 6, 5s, 6, 6+ will be wide screen.
  *
  *  @return YES if screen is wider than iPhone 4 / 4s and iPad.
  */
-BOOL ADKIsWideScreen();
+BOOL ADKIsWideScreen(void);
 
 /**
  *  @brief Check device's OS version is below iOS 7.
  *
  *  @return YES if OS verion is below 7.
  */
-BOOL ADKIsBelowIOS7();
+BOOL ADKIsBelowIOS7(void);
 
 /**
  *  @brief Check device's OS version is below iOS 8.
  *
  *  @return YES if OS verion is below 8.
  */
-BOOL ADKIsBelowIOS8();
+BOOL ADKIsBelowIOS8(void);
 
 /**
  *  @brief Check device's OS version is below iOS 9.
  *
  *  @return YES if OS verion is below 9.
  */
-BOOL ADKIsBelowIOS9();
+BOOL ADKIsBelowIOS9(void);
 
 /**
  *  @brief Check device's OS version is below iOS 10.
  *
  *  @return YES if OS verion is below 10.
  */
-BOOL ADKIsBelowIOS10();
+BOOL ADKIsBelowIOS10(void);
 
 /**
  *  @brief Check whether location services available. This is an expensive call. It should not be called frequently or from performance sensitive code.
  *
  *  @return YES if location services enabled and authorized, NO otherwise.
  */
-BOOL ADKIsLocationServicesAvailableOrNotDetermined();
+BOOL ADKIsLocationServicesAvailableOrNotDetermined(void);
 
 
 /**
@@ -66,18 +66,18 @@ BOOL ADKIsLocationServicesAvailableOrNotDetermined();
  *
  *  @return CGFloat
  */
-CGFloat ADKPortraitScreenRatio();
+CGFloat ADKPortraitScreenRatio(void);
 
 /**
  *  @brief Return a screen size (Alway in portrait orientation)
  *
  *  @return CGSize
  */
-CGSize ADKPortraitScreenSize();
+CGSize ADKPortraitScreenSize(void);
 
 /**
  *  @brief Return a screen bound (Alway in portrait orientation)
  *
  *  @return CGRect
  */
-CGRect ADKPortraitScreenBoundRect();
+CGRect ADKPortraitScreenBoundRect(void);

--- a/AppDevPods/AppDevCommonKit/ADKCalculatorHelper.h
+++ b/AppDevPods/AppDevCommonKit/ADKCalculatorHelper.h
@@ -54,11 +54,12 @@ CGRect ADKExtendToScreenWidth(CGRect Frame);
  *
  *  @return Expected CGSize.
  */
-CGSize ADKCGSizeZeroHeight();
+CGSize ADKCGSizeZeroHeight(void);
 
 /**
  *  @brief return a device's screen size.
  *
  *  @return Expected CGSize.
  */
-CGSize ADKScreenSize();
+CGSize ADKScreenSize(void);
+

--- a/AppDevPods/AppDevCommonKit/ADKStringHelper.h
+++ b/AppDevPods/AppDevCommonKit/ADKStringHelper.h
@@ -103,11 +103,11 @@ NSString *ADKFirstNonEmptyString(NSInteger num, ...);
 /**
  *  @brief Getting the application Document file path.
  */
-NSString *ADKApplicationDocumentsDirectory();
+NSString *ADKApplicationDocumentsDirectory(void);
 
 /**
  *  @brief Getting the [application]/library/cache file path.
  *
  *  @return path of cache directory
  */
-NSString *ADKApplicationCacheDirectory();
+NSString *ADKApplicationCacheDirectory(void);

--- a/AppDevPods/AppDevUIKit/UIScrollView+ADKInfiniteScrollingView.m
+++ b/AppDevPods/AppDevUIKit/UIScrollView+ADKInfiniteScrollingView.m
@@ -270,11 +270,15 @@ State diagram:
 
          */
 
-        CGFloat contentInsetBottom =
 #ifdef __IPHONE_11_0
-            (@available(iOS 11.0, *)) ? self.scrollView.adjustedContentInset.bottom : self.scrollView.contentInset.bottom
+        CGFloat contentInsetBottom;
+        if (@available(iOS 11.0, *)) {
+            contentInsetBottom = self.scrollView.adjustedContentInset.bottom;
+        } else {
+            contentInsetBottom = self.scrollView.contentInset.bottom;
+        }
 #else
-            self.scrollView.contentInset.bottom
+        CGFloat contentInsetBottom = self.scrollView.contentInset.bottom
 #endif
         ;
 


### PR DESCRIPTION
* Fix `This function declaration is not a prototype` warning
* Fix `@available does not guard availability here; use if (@available) instead` warning. Looks like Apple doesn't like the idea of using `@available` in `?:`