### PR TITLE
Fix return type of ADKNibCacheManager methods

### DIFF
--- a/AppDevPods/AppDevCommonKit/ADKNibCacheManager.h
+++ b/AppDevPods/AppDevCommonKit/ADKNibCacheManager.h
@@ -27,7 +27,7 @@
  *
  * @return instance of the cached class.
  */
-- (instancetype)instanceForNibNamed:(NSString *)nibName;
+- (id)instanceForNibNamed:(NSString *)nibName;
 
 /**
  * @brief This is a method for get singleton instance from class file.
@@ -36,6 +36,6 @@
  *
  * @return instance of the cached class.
  */
-- (instancetype)instanceForClassNamed:(NSString *)className;
+- (id)instanceForClassNamed:(NSString *)className;
 
 @end

--- a/AppDevPods/AppDevCommonKit/ADKNibCacheManager.m
+++ b/AppDevPods/AppDevCommonKit/ADKNibCacheManager.m
@@ -35,7 +35,7 @@
     return instance;
 }
 
-- (instancetype)instanceForNibNamed:(NSString *)nibName
+- (id)instanceForNibNamed:(NSString *)nibName
 {
     id classInstance = nil;
     NSString *nibNameKey = [nibName stringByAppendingPathComponent:@"nib"];
@@ -58,7 +58,7 @@
     return classInstance;
 }
 
-- (instancetype)instanceForClassNamed:(NSString *)className
+- (id)instanceForClassNamed:(NSString *)className
 {
     id classInstance = nil;
     NSString *classNameKey = [className stringByAppendingPathComponent:@"class"];


### PR DESCRIPTION
The object returned by `-[ADKNibCacheManager instanceForNibNamed:]` (and `-[ADKNibCacheManager instanceForClassNamed:]`) is not an ADKNibCacheManager object. Change it's return type to `id`.