### PR TITLE
align input formats of ADKColorWithHexString and ADKInitWithHexString

### DIFF
--- a/AppDevKitTests/AppDevCommonKit/UIColor+ADKHexPresentationSpec.m
+++ b/AppDevKitTests/AppDevCommonKit/UIColor+ADKHexPresentationSpec.m
@@ -36,6 +36,24 @@ describe(@"Test ADKColorWithHexString:", ^{
         UIColor *testColor = [UIColor ADKColorWithHexString:@"7b0099"];
         [[testColor should] equal:expectedColor];
     });
+
+    it(@"given color with #7b0099, expect color should be 7b0099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        UIColor *testColor = [UIColor ADKColorWithHexString:@"#7b0099"];
+        [[testColor should] equal:expectedColor];
+    });
+
+    it(@"given color with 709, expect color should be 770099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        UIColor *testColor = [UIColor ADKColorWithHexString:@"709"];
+        [[testColor should] equal:expectedColor];
+    });
+
+    it(@"given color with #709, expect color should be 770099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        UIColor *testColor = [UIColor ADKColorWithHexString:@"#709"];
+        [[testColor should] equal:expectedColor];
+    });
 });
 
 describe(@"Test ADKColorWithHexString:alpha:", ^{
@@ -50,6 +68,24 @@ describe(@"Test ADKInitWithHexString:", ^{
     it(@"expect color should be 7b0099", ^{
         UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
         UIColor *testColor = [[UIColor alloc] ADKInitWithHexString:@"7b0099"];
+        [[testColor should] equal:expectedColor];
+    });
+
+    it(@"given color with #7b0099, expect color should be 7b0099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        UIColor *testColor = [[UIColor alloc] ADKInitWithHexString:@"#7b0099"];
+        [[testColor should] equal:expectedColor];
+    });
+
+    it(@"given color with 709, expect color should be 770099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        UIColor *testColor = [[UIColor alloc] ADKInitWithHexString:@"709"];
+        [[testColor should] equal:expectedColor];
+    });
+
+    it(@"given color with #709, expect color should be 770099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        UIColor *testColor = [[UIColor alloc] ADKInitWithHexString:@"#709"];
         [[testColor should] equal:expectedColor];
     });
 });
@@ -82,6 +118,16 @@ describe(@"Test ADKColorWithRGBHexString", ^{
         UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
         [[[UIColor ADKColorWithRGBHexString:@"7B0099"] should] equal:expectedColor];
     });
+
+    it(@"given color with 709, expect color should be 770099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        [[[UIColor ADKColorWithRGBHexString:@"709"] should] equal:expectedColor];
+    });
+
+    it(@"given color with #709, expect color should be 770099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        [[[UIColor ADKColorWithRGBHexString:@"#709"] should] equal:expectedColor];
+    });
 });
 
 describe(@"Test ADKColorWithARGBHexString", ^{
@@ -89,12 +135,52 @@ describe(@"Test ADKColorWithARGBHexString", ^{
         UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0f / 255.0f blue:153.0f / 255.0f alpha:238.0f / 255.0f];
         [[[UIColor ADKColorWithARGBHexString:@"EE7B0099"] should] equal:expectedColor];
     });
+
+    it(@"given color with 7B0099, expect color should be FF7B0099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0f / 255.0f blue:153.0f / 255.0f alpha:255.0f / 255.0f];
+        [[[UIColor ADKColorWithARGBHexString:@"7B0099"] should] equal:expectedColor];
+    });
+
+    it(@"given color with E709, expect color should be EE770099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0f / 255.0f blue:153.0f / 255.0f alpha:238.0f / 255.0f];
+        [[[UIColor ADKColorWithARGBHexString:@"E709"] should] equal:expectedColor];
+    });
+
+    it(@"given color with 709, expect color should be FF770099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0f / 255.0f blue:153.0f / 255.0f alpha:255.0f / 255.0f];
+        [[[UIColor ADKColorWithARGBHexString:@"709"] should] equal:expectedColor];
+    });
+
+    it(@"given color with #709, expect color should be FF770099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0f / 255.0f blue:153.0f / 255.0f alpha:255.0f / 255.0f];
+        [[[UIColor ADKColorWithARGBHexString:@"#709"] should] equal:expectedColor];
+    });
 });
 
 describe(@"Test ADKColorWithRGBAHexString", ^{
     it(@"expect color should be 7B0099EE", ^{
         UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0f / 255.0f blue:153.0f / 255.0f alpha:238.0f / 255.0f];
         [[[UIColor ADKColorWithRGBAHexString:@"7B0099EE"] should] equal:expectedColor];
+    });
+
+    it(@"given color with 7B0099, expect color should be 7B0099FF", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0f / 255.0f blue:153.0f / 255.0f alpha:255.0f / 255.0f];
+        [[[UIColor ADKColorWithRGBAHexString:@"7B0099"] should] equal:expectedColor];
+    });
+
+    it(@"given color with 709E, expect color should be 770099EE", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0f / 255.0f blue:153.0f / 255.0f alpha:238.0f / 255.0f];
+        [[[UIColor ADKColorWithRGBAHexString:@"709E"] should] equal:expectedColor];
+    });
+
+    it(@"given color with 709, expect color should be 770099FF", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0f / 255.0f blue:153.0f / 255.0f alpha:255.0f / 255.0f];
+        [[[UIColor ADKColorWithRGBAHexString:@"709"] should] equal:expectedColor];
+    });
+
+    it(@"given color with #709, expect color should be 770099FF", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0f / 255.0f blue:153.0f / 255.0f alpha:255.0f / 255.0f];
+        [[[UIColor ADKColorWithRGBAHexString:@"#709"] should] equal:expectedColor];
     });
 });
 

--- a/AppDevKitTests/AppDevCommonKit/UIColor+ADKHexPresentationSpec.m
+++ b/AppDevKitTests/AppDevCommonKit/UIColor+ADKHexPresentationSpec.m
@@ -43,6 +43,18 @@ describe(@"Test ADKColorWithHexString:", ^{
         [[testColor should] equal:expectedColor];
     });
 
+    it(@"given color with 0x7b0099, expect color should be 7b0099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        UIColor *testColor = [UIColor ADKColorWithHexString:@"0x7b0099"];
+        [[testColor should] equal:expectedColor];
+    });
+
+    it(@"given color with 0X7b0099, expect color should be 7b0099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        UIColor *testColor = [UIColor ADKColorWithHexString:@"0X7b0099"];
+        [[testColor should] equal:expectedColor];
+    });
+
     it(@"given color with 709, expect color should be 770099", ^{
         UIColor *expectedColor = [UIColor colorWithRed:119.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
         UIColor *testColor = [UIColor ADKColorWithHexString:@"709"];
@@ -74,6 +86,18 @@ describe(@"Test ADKInitWithHexString:", ^{
     it(@"given color with #7b0099, expect color should be 7b0099", ^{
         UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
         UIColor *testColor = [[UIColor alloc] ADKInitWithHexString:@"#7b0099"];
+        [[testColor should] equal:expectedColor];
+    });
+
+    it(@"given color with 0x7b0099, expect color should be 7b0099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        UIColor *testColor = [[UIColor alloc] ADKInitWithHexString:@"0x7b0099"];
+        [[testColor should] equal:expectedColor];
+    });
+
+    it(@"given color with 0X7b0099, expect color should be 7b0099", ^{
+        UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+        UIColor *testColor = [[UIColor alloc] ADKInitWithHexString:@"0X7b0099"];
         [[testColor should] equal:expectedColor];
     });
 

--- a/AppDevPods/AppDevCommonKit/UIColor+ADKHexPresentation.m
+++ b/AppDevPods/AppDevCommonKit/UIColor+ADKHexPresentation.m
@@ -19,7 +19,7 @@
 
 - (UIColor *)ADKInitWithHexRed:(NSUInteger)red green:(NSUInteger)green blue:(NSUInteger)blue alpha:(CGFloat)alpha
 {
-    return [[UIColor alloc] initWithRed:red / (0xff*1.0f) green:green / (0xff*1.0f) blue:blue / (0xff*1.0f) alpha:alpha];
+    return [self initWithRed:red / (0xff*1.0f) green:green / (0xff*1.0f) blue:blue / (0xff*1.0f) alpha:alpha];
 }
 
 + (UIColor *)ADKColorWithHexString:(NSString *)hexString
@@ -34,14 +34,7 @@
 
 - (UIColor *)ADKInitWithHexString:(NSString *)hexString
 {
-    NSUInteger rgbValue = 0;
-    NSScanner *scanner = [NSScanner scannerWithString:hexString];
-    if ( [hexString hasPrefix:@"#"] ) {
-        [scanner setScanLocation:1];
-    }
-    [scanner scanHexInt:(unsigned int *)&rgbValue];
-    
-    return [self ADKInitWithHexNumber:rgbValue];
+    return [self.class ADKColorWithRGBHexString:hexString];
 }
 
 + (UIColor *)ADKColorWithRGBHexString:(NSString *)hexString

--- a/AppDevPods/AppDevCommonKit/UIColor+ADKHexPresentation.m
+++ b/AppDevPods/AppDevCommonKit/UIColor+ADKHexPresentation.m
@@ -24,7 +24,11 @@
 
 + (UIColor *)ADKColorWithHexString:(NSString *)hexString
 {
-    return [self ADKColorWithRGBHexString:hexString];
+    if ([hexString hasPrefix:@"0x"] || [hexString hasPrefix:@"0X"]) {
+        return [self ADKColorWithRGBHexString:[hexString substringFromIndex:2]];
+    } else {
+        return [self ADKColorWithRGBHexString:hexString];
+    }
 }
 
 + (UIColor *)ADKColorWithHexString:(NSString *)hexString alpha:(CGFloat)alpha
@@ -34,7 +38,11 @@
 
 - (UIColor *)ADKInitWithHexString:(NSString *)hexString
 {
-    return [self.class ADKColorWithRGBHexString:hexString];
+    if ([hexString hasPrefix:@"0x"] || [hexString hasPrefix:@"0X"]) {
+        return [self.class ADKColorWithRGBHexString:[hexString substringFromIndex:2]];
+    } else {
+        return [self.class ADKColorWithRGBHexString:hexString];
+    }
 }
 
 + (UIColor *)ADKColorWithRGBHexString:(NSString *)hexString


### PR DESCRIPTION
This pull request is for issue https://github.com/yahoo/AppDevKit/issues/80

Align the accepted color code formats of `ADKColorWithHexString:` and `ADKInitWithHexString:`.

Before:
- `ADKColorWithHexString:` handles formats like #RRGGBB, RRGGBB, #RGB, RGB
- `ADKInitWithHexString:` handles formats like #RRGGBB, RRGGBB, 0xRRGGBB

After:
- make both methods support #RRGGBB, RRGGBB, #RGB, RGB, 0xRRGGBB

## Unit test
- `ADKColorWithHexString` and `ADKInitWithHexString`:
   - add cases to include above formats
- `ADKColorWithRGBHexString`, `ADKColorWithARGBHexString` and `ADKColorWithRGBAHexString`:
  - add cases for all formats it supports
