### PR TITLE
Fix ADKIsEqualToColor

### DIFF
--- a/AppDevKit.podspec
+++ b/AppDevKit.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.license      = "Yahoo! Inc. BSD license"
 
   s.author       = { "anistar sung" => "cfsung@yahoo-inc.com", "core team" => "app-dev-kit@yahoo-inc.com" }
-  s.platform     = :ios, "7.0"
-  s.ios.deployment_target = '7.0'
+  s.platform     = :ios, "10.0"
+  s.ios.deployment_target = '10.0'
 
   s.subspec 'AppDevCommonKit' do |appDevCommonKit|
       appDevCommonKit.source_files = ['AppDevPods/AppDevCommonKit/**/*', 'AppDevPods/AppDevCommonKit.h']

--- a/AppDevKitTests/AppDevCommonKit/UIColor+ADKHexPresentationSpec.m
+++ b/AppDevKitTests/AppDevCommonKit/UIColor+ADKHexPresentationSpec.m
@@ -208,4 +208,30 @@ describe(@"Test ADKColorWithRGBAHexString", ^{
     });
 });
 
+describe(@"Test ADKIsEqualToColor", ^{
+    it(@"given color with white:0.0, expect to be equal to black color", ^{
+        UIColor *expectedColor = [UIColor blackColor];
+        UIColor *testColor = [UIColor colorWithWhite:0.0f alpha:1.0f];
+        [[theValue([testColor ADKIsEqualToColor:expectedColor]) should] beYes];
+    });
+
+    it(@"given color with white:0.1, expect to be not equal to black color", ^{
+        UIColor *expectedColor = [UIColor blackColor];
+        UIColor *testColor = [UIColor colorWithWhite:0.1f alpha:1.0f];
+        [[theValue([testColor ADKIsEqualToColor:expectedColor]) should] beNo];
+    });
+
+    it(@"given color with FF0000, expect to be equal to red color", ^{
+        UIColor *expectedColor = [UIColor redColor];
+        UIColor *testColor = [UIColor colorWithRed:1.0f green:0.0f blue:0.0f alpha:1.0f];
+        [[theValue([testColor ADKIsEqualToColor:expectedColor]) should] beYes];
+    });
+
+    it(@"given color with 00FF00, expect to be not equal to red color", ^{
+        UIColor *expectedColor = [UIColor redColor];
+        UIColor *testColor = [UIColor colorWithRed:0.0f green:1.0f blue:0.0f alpha:1.0f];
+        [[theValue([testColor ADKIsEqualToColor:expectedColor]) should] beNo];
+    });
+});
+
 SPEC_END

--- a/AppDevPods/AppDevCommonKit/UIColor+ADKHexPresentation.m
+++ b/AppDevPods/AppDevCommonKit/UIColor+ADKHexPresentation.m
@@ -191,9 +191,9 @@
 {
     if (self == anotherColor)
         return YES;
-    
-    CGColorSpaceRef colorSpaceRGB = CGColorSpaceCreateDeviceRGB();
-    
+
+    CGColorSpaceRef colorSpaceRGB = CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB);
+
     UIColor *(^convertColorToRGBSpace)(UIColor*) = ^(UIColor *color)
     {
         if (CGColorSpaceGetModel(CGColorGetColorSpace(color.CGColor)) == kCGColorSpaceModelMonochrome)

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 # AppDevKit
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '7.0'
+platform :ios, '10.0'
 
 target 'AppDevKit' do
 


### PR DESCRIPTION
This pull request contains two changes.

1. Update `AppDevKit.podspec` and `Podfile` to match with the current value `IPHONEOS_DEPLOYMENT_TARGET = 10.0;` in `project.pbxproj`
   - https://github.com/yahoo/AppDevKit/blob/54af35c/AppDevKit.xcodeproj/project.pbxproj#L1429

2. Since we have raised the minimum required version to iOS 10, update `ADKIsEqualToColor` to use extended color space (instead of device-dependent RGB).
   - this is to fix the issue https://github.com/yahoo/AppDevKit/issues/81
