### PR TITLE
Correct ColorHexString with only 2 components

### DIFF
--- a/AppDevKitTests/AppDevCommonKit/UIColor+ADKHexPresentationSpec.m
+++ b/AppDevKitTests/AppDevCommonKit/UIColor+ADKHexPresentationSpec.m
@@ -135,6 +135,16 @@ describe(@"Test ADKHexString", ^{
         UIColor *expectedColor = [UIColor colorWithRed:123.0f / 255.0f green:0.0 / 255.0f blue:153.0f / 255.0f alpha:1.0f];
         [[[expectedColor ADKHexString] should] equal:@"7B0099"];
     });
+
+    it(@"given white color, should get string FFFFFF", ^{
+        UIColor *expectedColor = [UIColor whiteColor];
+        [[[expectedColor ADKHexString] should] equal:@"FFFFFF"];
+    });
+
+    it(@"given black color, should get string 000000", ^{
+        UIColor *expectedColor = [UIColor blackColor];
+        [[[expectedColor ADKHexString] should] equal:@"000000"];
+    });
 });
 
 describe(@"Test ADKColorWithRGBHexString", ^{

--- a/AppDevPods/AppDevCommonKit/UIColor+ADKHexPresentation.m
+++ b/AppDevPods/AppDevCommonKit/UIColor+ADKHexPresentation.m
@@ -219,12 +219,19 @@
 - (NSString *)ADKHexString
 {
     const CGFloat *components = CGColorGetComponents(self.CGColor);
+    CGFloat red, green, blue;
 
-    CGFloat red = components[0];
-    CGFloat greeen = components[1];
-    CGFloat blue = components[2];
+    if (CGColorGetNumberOfComponents(self.CGColor) == 2) {
+        red = components[0];
+        green = components[0];
+        blue = components[0];
+    } else {
+        red = components[0];
+        green = components[1];
+        blue = components[2];
+    }
 
-    return [NSString stringWithFormat:@"%02lX%02lX%02lX", lroundf(red * 255), lroundf(greeen * 255), lroundf(blue * 255)];
+    return [NSString stringWithFormat:@"%02lX%02lX%02lX", lroundf(red * 255), lroundf(green * 255), lroundf(blue * 255)];
 }
 
 @end


### PR DESCRIPTION
CGColorGetComponents might only have 2 components if is black or white

https://stackoverflow.com/a/9238912